### PR TITLE
feature/redirect from old to new sites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 install:
-  - pip install mkdocs-material
+  - pip install mkdocs-material mkdocs-redirects
 
 script:
   - mkdocs build --clean --strict

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,12 @@ markdown_extensions:
   - admonition
   - codehilite
 
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        "recheck/how-ignore-works-in-recheck.md": "recheck/how-ignore-works.md"
+
 repo_name: "retest/docs"
 repo_url: "https://github.com/retest/docs"
 extra:


### PR DESCRIPTION
This should fix retest/recheck-web#358.

I looked into this a day or two ago and thought it not to be possible, but today first result a hit.

I tested it with WSL as apparently the plugin does not find the correct file on Windows due to path separator. That said: It should work, but we need to give it a try once deployed.

![redirect](https://user-images.githubusercontent.com/10256143/65341688-324bff80-dbd1-11e9-9149-a9c4c74372fd.png)