### PR TITLE
Add missing description to match threshold

### DIFF
--- a/docs/recheck/usage/configuration.md
+++ b/docs/recheck/usage/configuration.md
@@ -117,6 +117,7 @@ key=${DEFAULT_VALUE}
 # Any valid absolute path.
 de.retest.recheck.project.root=null
 # Minimal match threshold between old and new element to safely assume it's actually the same. 
+# Any double in the interval [0.0, 1.0].
 de.retest.recheck.elementMatchThreshold=0.3
 ```
 


### PR DESCRIPTION
Looking at the format from #61 reminded me, that we put the possible values below the description. However, I already approved and was too slow to revoke my approval. Thus this PR.

> Any double in the interval [0.0, 1.0]

Is this functionally correct? Since you mentioned it in your [comment](https://github.com/retest/recheck-web/pull/422#discussion_r345933636) that the comparism happens with `x > 1.0` which never can happen!? With this information, mathematically, it should be the interval of `[0.0, 1.0)` or a check with a margin due to [double comparism](https://stackoverflow.com/a/8081911): `x > 1.0±1E-10`

