### PR TITLE
Use correct URL to MkDocs project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For the rendered documentation, please go to https://retest.github.io/docs/.
 
 ## Installation
 
-We use [MkDocs](https://mkdocs.org/) to build and deploy the documentation. Please refer to the official [installation guide](https://www.mkdocs.org/#installation).
+We use [MkDocs](https://www.mkdocs.org/) to build and deploy the documentation. Please refer to the official [installation guide](https://www.mkdocs.org/#installation).
 
 ## Commands
 


### PR DESCRIPTION
Without the `www.` prefix, users will end up on a page with a certificate warning.