### PR TITLE
Update clean up config for Eclipse

### DIFF
--- a/docs/contributing/retest-clean-up.xml
+++ b/docs/contributing/retest-clean-up.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="2">
     <profile kind="CleanUpProfile" name="ReTest" version="2">
+        <setting id="cleanup.use_autoboxing" value="false"/>
         <setting id="cleanup.qualify_static_method_accesses_with_declaring_class" value="false"/>
         <setting id="cleanup.always_use_this_for_non_static_method_access" value="false"/>
         <setting id="cleanup.organize_imports" value="true"/>
         <setting id="cleanup.remove_trailing_whitespaces_ignore_empty" value="false"/>
+        <setting id="cleanup.use_directly_map_method" value="false"/>
         <setting id="cleanup.format_source_code_changes_only" value="false"/>
         <setting id="cleanup.qualify_static_field_accesses_with_declaring_class" value="false"/>
         <setting id="cleanup.add_generated_serial_version_id" value="false"/>
@@ -15,11 +17,13 @@
         <setting id="cleanup.insert_inferred_type_arguments" value="false"/>
         <setting id="cleanup.make_private_fields_final" value="true"/>
         <setting id="cleanup.use_lambda" value="true"/>
+        <setting id="cleanup.simplify_lambda_expression_and_method_ref" value="true"/>
         <setting id="cleanup.always_use_blocks" value="true"/>
         <setting id="cleanup.use_this_for_non_static_field_access_only_if_necessary" value="true"/>
         <setting id="cleanup.sort_members_all" value="false"/>
         <setting id="cleanup.remove_trailing_whitespaces_all" value="true"/>
         <setting id="cleanup.add_missing_annotations" value="true"/>
+        <setting id="cleanup.remove_unnecessary_array_creation" value="false"/>
         <setting id="cleanup.always_use_this_for_non_static_field_access" value="false"/>
         <setting id="cleanup.make_parameters_final" value="true"/>
         <setting id="cleanup.sort_members" value="false"/>
@@ -30,15 +34,17 @@
         <setting id="cleanup.remove_unused_private_fields" value="true"/>
         <setting id="cleanup.remove_redundant_modifiers" value="false"/>
         <setting id="cleanup.never_use_blocks" value="false"/>
+        <setting id="cleanup.number_suffix" value="false"/>
         <setting id="cleanup.add_missing_deprecated_annotations" value="true"/>
         <setting id="cleanup.use_this_for_non_static_field_access" value="true"/>
         <setting id="cleanup.remove_unnecessary_nls_tags" value="true"/>
         <setting id="cleanup.qualify_static_member_accesses_through_instances_with_declaring_class" value="true"/>
         <setting id="cleanup.add_missing_nls_tags" value="false"/>
         <setting id="cleanup.remove_unnecessary_casts" value="true"/>
+        <setting id="cleanup.use_unboxing" value="false"/>
         <setting id="cleanup.use_blocks_only_for_return_and_throw" value="false"/>
         <setting id="cleanup.format_source_code" value="true"/>
-        <setting id="cleanup.convert_functional_interfaces" value="false"/>
+        <setting id="cleanup.convert_functional_interfaces" value="true"/>
         <setting id="cleanup.add_default_serial_version_id" value="true"/>
         <setting id="cleanup.remove_unused_private_methods" value="true"/>
         <setting id="cleanup.remove_trailing_whitespaces" value="true"/>
@@ -53,6 +59,7 @@
         <setting id="cleanup.add_missing_methods" value="false"/>
         <setting id="cleanup.never_use_parentheses_in_expressions" value="true"/>
         <setting id="cleanup.qualify_static_member_accesses_with_declaring_class" value="false"/>
+        <setting id="cleanup.push_down_negation" value="false"/>
         <setting id="cleanup.use_parentheses_in_expressions" value="true"/>
         <setting id="cleanup.add_missing_override_annotations" value="true"/>
         <setting id="cleanup.use_blocks" value="true"/>


### PR DESCRIPTION
This adds some new options introduced as part of Eclipse 2020-03 (4.15.0). As can be seen, most of these are false (default value). The changes I have introduced are two things I find very helpful when dealing with lambdas:

# Convert functional interface instances

```java
IntConsumer c = new IntConsumer() {
    @Override public void accept(int value) {
        System.out.println(i);
    }
};
```

Becomes:

```java
IntConsumer c = i -> {
    System.out.println(i);
};
```

# Simplify lambda expressions and method reference syntax

Removes unnecessary returns as well as curly braces, and uses method references whenever possible.

---

As soon as this is merged, I would inform the #dev channel to update their configs.