### PR TITLE
Feature/exclude filter

### DIFF
--- a/docs/recheck/usage/filter.md
+++ b/docs/recheck/usage/filter.md
@@ -226,22 +226,6 @@ $attribute, $color-diff
 !!! tip
     By combining element, attribute and value matching, you are able to match certain differences very specifically.
 
-### Importing Filters
-
-To avoid having huge filter or ignore files and to avoid redundancy, you can create smaller, specialized filters which you can import.
-
-The import is specified by the filter name (i.e. the file name), which will look at the global scope of all filters to find the most specific one. For example using the below example, will search all available [locations](#location) for the file name and choose the most specific filter to load. This way, the importing filter will always pick up any changes made to the imported filter. 
-
-```properties
-# Import other filters based on the name
-import: content.filter
-```
-
-!!! warning
-    Be careful not to use cyclic imports where `a.filter` imports `b.filter` and vice versa (same goes for longer cyclic chains).
-    
-    Secondly, only import filters from the same or a broader scope (e.g. filters within the user home should only import filters present in the user home or provided locations). If need be, you can always overwrite these filters within the project directory and the importing filter will use the project filter if available.
-
 ### Matching Elements
 
 Elements are identified by one special attribute `$key`, so called *identifying attributes*. 
@@ -334,5 +318,20 @@ color-diff=5%
 ```
 
 Each color component (red, green, blue) is reviews in isolation. Changing only the red component from `255` to `127` would result in a color difference of 50%.
+
+### Importing Filters
+
+To avoid having huge filter or ignore files and to avoid redundancy, you can create smaller, specialized filters which you can import.
+
+The import is specified by the filter name (i.e. the file name), which will look at the global scope of all filters to find the most specific one. For example using the below example, will search all available [locations](#location) for the file name and choose the most specific filter to load. This way, the importing filter will always pick up any changes made to the imported filter. 
+
+```properties
+# Import other filters based on the name
+import: content.filter
+```
+!!! warning
+    Be careful not to use cyclic imports where `a.filter` imports `b.filter` and vice versa (same goes for longer cyclic chains).
+    
+    Secondly, only import filters from the same or a broader scope (e.g. filters within the user home should only import filters present in the user home or provided locations). If need be, you can always overwrite these filters within the project directory and the importing filter will use the project filter if available.
 
 [^1]: While the HTML tag name is mapped to `type` and part of the identifying attributes, the actual HTML `type` is put into the ordinary attributes that define an element's state.

--- a/docs/recheck/usage/filter.md
+++ b/docs/recheck/usage/filter.md
@@ -136,6 +136,29 @@ foo # Comment lines must start with a '#' and do not have leading whitespaces
 
 Each line represents a filter, which itself can be made up by one or more expressions. Those expressions are separated with a comma and a whitespace `, `.
 
+When writing expressions, it is important to understand that filters are additive. Take the example below where each filter refers to a different element. Please refer to the individual expressions below to lookup their usage in detail.
+
+```properties
+# Matches all elements and their attributes within a form element
+matcher: type=form
+# Matches the text attribute for all elements within body
+matcher: type=body, attribute=text
+```
+
+If a filter refers to the same element, care must be taken, so that each filter is evaluated.
+
+```properties
+# Matches all elements and their attributes within a body element
+matcher: type=body
+# Matches the text attribute for all elements witin body
+# Will not be evaluated, because the above filter already matches
+matcher: type=body, attribute=text
+```
+
+Since filters are evaluated top to bottom, we could switch both lines around. But since the body will be matched completely, regardless of the order, the more specific attribute is unnecessary.
+
+Thus it should be taken care, that each filter line references a unique [scope](#scope), so that each line is evaluated and contributes to the filter as a whole.
+
 #### Scope
 
 Each expression applies to a specific scope. By default, a global scope is assumed (i.e. the [`report`](../files/report.md) or [`state`](../files/state.md)) to which the resulting filter is applied. By chaining multiple expression within a single line, the following expression acts only upon the scope of the previous expression, while the last expression ultimately decides which final scope the filter applies.

--- a/docs/recheck/usage/filter.md
+++ b/docs/recheck/usage/filter.md
@@ -150,7 +150,7 @@ If a filter refers to the same element, care must be taken, so that each filter 
 ```properties
 # Matches all elements and their attributes within a body element
 matcher: type=body
-# Matches the text attribute for all elements witin body
+# Matches the text attribute for all elements within body
 # Will not be evaluated, because the above filter already matches
 matcher: type=body, attribute=text
 ```
@@ -163,7 +163,7 @@ Thus it should be taken care, that each filter line references a unique [scope](
 
 Each expression applies to a specific scope. By default, a global scope is assumed (i.e. the [`report`](../files/report.md) or [`state`](../files/state.md)) to which the resulting filter is applied. By chaining multiple expression within a single line, the following expression acts only upon the scope of the previous expression, while the last expression ultimately decides which final scope the filter applies.
 
-A filter executes its expressions lazily (left to right) and aborts as soon as the scope is empty. Consequently, it will only match, if the last scope analyzed is not empty. Thus, an expression is only evaluated, if the applying scope is not empty
+A filter executes its expressions lazily (left to right) and aborts as soon as the scope is empty. Consequently, it will only match, if the last scope analyzed is not empty. Thus, an expression is only evaluated, if the applying scope is not empty.
 
 ##### State
 
@@ -390,7 +390,7 @@ matcher: type=p, exclude(attribute=text)
 It is important to understand that filters are [additive](#expression), where each line must represent a complete filter. The same applies for excluding filters. If a exclusion binds to the same [scope](#scope) (e.g. a `form` element), they **must** be chained together.
 
 ```properties
-# Match all elements witin a form, except buttons
+# Match all elements within a form, except buttons
 matcher: type=form, exclude(type=button)
 # Match all elements within a form, except input elements
 # Will not be evaluated, because the above filter already matches 
@@ -432,7 +432,7 @@ matcher: type=form, exclude(matcher: type=input, attribute=text), exclude(matche
 
 Excluding filters can both be chained and nested, if the [scope](#examples) allows for it. Take a look at the example below.
 
-You can exclusion expression chaining:
+You can use exclusion expression chaining:
 
 ```properties
 matcher: id=body, exclude(attribute=text), exclude(matcher: id=btn-subscribe), exclude(matcher: id=div, exclude(matcher: id=form))

--- a/docs/recheck/usage/filter.md
+++ b/docs/recheck/usage/filter.md
@@ -134,7 +134,40 @@ foo # Comment lines must start with a '#' and do not have leading whitespaces
 
 ### Expressions
 
-A filter is built up using one or multiple expressions. By chaining multiple expressions together using a comma with a whitespace `, `, you are able to more precisely specify what the filter should match. Note that the order of the expressions is important, which is lazily executed from left to right and stops once an expression does not match anymore. See the examples below for the possible chainable expressions.
+Each line represents a filter, which itself can be made up by one or more expressions. Those expressions are separated with a comma and a whitespace `, `.
+
+#### Scope
+
+Each expression applies to a specific scope. By default, a global scope is assumed (i.e. the [`report`](../files/report.md) or [`state`](../files/state.md)) to which the resulting filter is applied. By chaining multiple expression within a single line, the following expression acts only upon the scope of the previous expression, while the last expression ultimately decides which final scope the filter applies.
+
+A filter executes its expressions lazily (left to right) and aborts as soon as the scope is empty. Consequently, it will only match, if the last scope analyzed is not empty. Thus, an expression is only evaluated, if the applying scope is not empty
+
+##### State
+
+Consider the element structure as represented by the [state](../files/state.md#data): A collection of elements, where each element contains attributes which are assigned to values. For that the following scopes can be defined:
+
+1. State (i.e. collection of elements): *This is the global scope*.
+2. Element: Select an element, e.g. type `button`.
+3. Attribute: Select an attribute, e.g. `background-color`.
+4. Value: Select the value, e.g. `rgb(125, 125, 125)`.
+
+In words: The above example selects all `button` elements with the attribute `background-color=rgb(125, 125, 125)`.
+
+##### Report
+
+Although the structure of a [report](../files/report.md#structure) is quite different, ultimately, the scope is fairly similar to the scope of a state.
+
+1. Report (i.e. collection of element differences): *This is the global scope*.
+2. Element: Select an element, e.g. type `button`. *The element difference is not exposed directly*.
+3. Attribute Difference: Select an attribute, e.g. `background-color`, 
+4. Value: Depending on the filter, this will select either the *expected* or *actual* value, e.g. `rgb(125, 125, 125)`.
+
+In words: The above example selects all `button` elements with the attribute difference `background-color: actual=rgb(125, 125, 125)`.
+
+!!! tip
+    When chaining multiple expressions, scopes may be omitted. For example, omitting the element scope for the above example would result in a selection of *all* elements with the respective background color.
+
+#### Examples
 
 We currently support these individual expressions. Please refer to the more in detail descriptions below:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.keys
+  - toc:
+      toc_depth: 4
 
 plugins:
   - search


### PR DESCRIPTION
This is related to retest/recheck#757.

## Description

This PR aims to explain the excluding filters. However, when writing this part, I realized that it is quite complex and requires some basic knowledge to how filters or expressions work.

### Scope

For that, I have reworked the basic expression introduction to explain in more detail how and on what an expression works. Similar to the [unbreakable scopes](https://docs.retest.de/recheck-web/introduction/usage/#unbreakable-scopes), I have introduced the term *Scope* into filters. Although, this is not how filters are implemented (tecnically), it is in general how they are perceived to work and gives an abstract overview to grasp what elements or attribute (difference) an expression affects. In fact, this is similar to how XPath describes their syntax (although they call it a *sequence*).

To explain a scope, I have started with the state, because its structure is easier and more aligned to what the filter syntax currently supports, even though recheck currently does not apply a filter to a state&mdash;although, it is technically possible to do so.

### Exclusion expression

Using the exclude expression differ from standard expressions a bit, but can be quite complex. Therefore the description is quite lengthy to cover some pitfalls users might encounter. I will not duplicate their explanation here, as this is the entire point of this PR.